### PR TITLE
Fix/tra 300 remove id from the admin panel

### DIFF
--- a/src/shared/components/table/table.component.tsx
+++ b/src/shared/components/table/table.component.tsx
@@ -44,6 +44,7 @@ export function Table({ columns, data, updateMyData }: TableProps) {
   const defaultColumn = {
     Cell: EditableCell,
   };
+  const initialState = { hiddenColumns: ['id'] };
 
   const {
     getTableProps,
@@ -62,6 +63,7 @@ export function Table({ columns, data, updateMyData }: TableProps) {
     state: { pageIndex, pageSize },
   } = useTable(
     {
+      initialState,
       columns,
       data,
       defaultColumn,


### PR DESCRIPTION
`ID` column had to be hidden because the form still needs the `id` property to update the entry

https://apptension.atlassian.net/browse/TRA-300